### PR TITLE
修复解析报告结果时文件为绝对路径的问题

### DIFF
--- a/python_unittest/pyproject.toml
+++ b/python_unittest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python_unittest"
-version = "0.2.14"
+version = "0.2.15"
 description = "Python unittest test tool for TestSolar"
 authors = [
     {name = "dzx-cptbtptp", email = "371140679@qq.com"},

--- a/python_unittest/pytest.ini
+++ b/python_unittest/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = tests/testdata

--- a/python_unittest/tests/test_result.py
+++ b/python_unittest/tests/test_result.py
@@ -6,4 +6,7 @@ testdata_dir: str = str(Path(__file__).parent.absolute().joinpath("testdata"))
 
 
 def test_parse_test_report():
-    parse_test_report(os.path.join(testdata_dir, "xml_results.xml"))
+    results = parse_test_report(
+        proj_path=testdata_dir, xml_file=os.path.join(testdata_dir, "xml_results.xml")
+    )
+    assert len(results) == 30

--- a/python_unittest/testtool.yaml
+++ b/python_unittest/testtool.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0
 name: python_unittest
 nameZh: python_unittest测试工具
 description: python_unittest自动化测试工具
-version: 0.2.14
+version: 0.2.15
 lang: python
 defaultBaseImage: mirrors.tencent.com/testsolar-base/python:3.9
 langType: INTERPRETED

--- a/python_unittest/uv.lock
+++ b/python_unittest/uv.lock
@@ -466,7 +466,7 @@ wheels = [
 
 [[package]]
 name = "python-unittest"
-version = "0.2.14"
+version = "0.2.15"
 source = { virtual = "." }
 dependencies = [
     { name = "coverage" },


### PR DESCRIPTION
报告结果文件中用例路径部分情况下为绝对路径，导致上报时不满足selector规范要求，因此需要兼容